### PR TITLE
Correct Markdown link to GeoJSON.tools

### DIFF
--- a/docs/cli/viewer-tool/index.md
+++ b/docs/cli/viewer-tool/index.md
@@ -6,7 +6,7 @@ that can quickly display data from various sources, highlight and inspect specif
 > #### Hint: GeoJSON Tool URL
 >
 > Bookmark the GeoJSON Tool at:
-> ![http://geojson.tools/](http://geojson.tools/)
+> [http://geojson.tools/](http://geojson.tools/)
 
 ![Data Hub GeoJSON Tool](images/viewer.png)
 


### PR DESCRIPTION
The markdown was for an image link instead of a hyperlink.

Signed-off-by: Jake Hendy <me@jakehendy.com>